### PR TITLE
似たような文字をかえすっぽいやつ　バージョン２

### DIFF
--- a/lib/oppai/cmd.rb
+++ b/lib/oppai/cmd.rb
@@ -6,7 +6,7 @@ class Oppai
       @white_methods = %w(count word flag per help version)
       @destroy_methods = %w(abort throw raise fail exit sleep
                             inspect new clone initialize)
-      @likely = LikelyKeyword.new(@white_methods + @destroy_methods)
+      @likely = LikelyKeyword.new(@white_methods + @destroy_methods,@white_methods)
       @data = data
     end
 

--- a/lib/oppai/cmd/likely_keyword.rb
+++ b/lib/oppai/cmd/likely_keyword.rb
@@ -2,13 +2,20 @@ class Oppai
   class Cmd
     # にたよーな文字をかえすっぽいやつ
     class LikelyKeyword
-      def initialize(keywords)
+      def initialize(keywords,keywordsTrie)
         @keywords = nil
         if keywords.is_a?(Array)
           @keywords = keywords
         elsif keywords.is_a?(String)
           @keywords = [keywords]
         end
+        @keywordsTrie = nil
+        if keywordsTrie.is_a?(Array)
+          @keywordsTrie = keywordsTrie
+        elsif keywordsTrie.is_a?(String)
+          @keywordsTrie = [keywordsTrie]
+        end
+        @trie = genTrie(@keywordsTrie)
       end
       def levenshtein(a,b)
         x = a.size
@@ -29,9 +36,9 @@ class Oppai
         }
         d[x][y]
       end
-      def words(keyword)
+      def levenshtein_words(keyword)
         change_min = 2
-        return [] if keyword.size < change_min
+        return [] if keyword.size <= change_min or @keywords.nil?
         kws = []
         max = change_min
         @keywords.each{|kw|
@@ -44,8 +51,35 @@ class Oppai
         }
         kws
       end
+      def genTrie(keywords)
+        trie = {:next => {}, :term => [] }
+        return trie if keywords.nil?
+        keywords.each{|kw|
+          tc = trie
+          kw.split(//).each{|c|
+            tc[:term].push(kw)
+            tc[:next][c] = {:next => {}, :term => []} if !tc[:next].has_key?(c)
+            tc = tc[:next][c]
+          }
+          tc[:term].push(kw)
+        }
+        trie
+      end
+      def trie_words(keyword)
+        return [] if keyword.size < 1
+        t = @trie
+        keyword.split(//).each{|c|
+          return [] if !t[:next].has_key?(c)
+          t = t[:next][c]
+        }
+        return t[:term]
+      end
       def word(keyword)
-        words(keyword).sample
+        words = levenshtein_words(keyword)
+        return words.sample if words.size > 0
+        words = trie_words(keyword)
+        return words.sample if words.size > 0
+        nil
       end
     end
   end


### PR DESCRIPTION
ばーじょん１の方法（似た文字）で引っかからなければ、white_methodsだけ前方一致するように変更
c w f p h vとかで、countっぱい？　が追加されてるはず。
（c、co、cou、coun、countどれでも引っかかるようにした）

似たような文字をかえすっぽいやつのバグ修正（２文字でも反応してた）のもこっそり治した
oppai he とかで new とか言われることがあるのの修正。
（２文字のheでもlevenshteinチェックしちゃってた）